### PR TITLE
[fidelity] Bug fix

### DIFF
--- a/beanhub_extract/extractors/fidelity.py
+++ b/beanhub_extract/extractors/fidelity.py
@@ -16,7 +16,7 @@ DATE_FIELD = "Run Date"
 
 
 def beanify_account(name: str) -> str:
-    rst = re.sub(r"[^a-zA-Z0-9-_:]", "", name)
+    rst = re.sub(r"[^a-zA-Z0-9-_: ]", "", name)
     rst = re.sub(r"[ \t\n\r\v\f]", " ", rst)
     rst = re.sub(r"[ ]{2,}", " ", rst)
     rst = rst.replace(" ", "-")

--- a/beanhub_extract/extractors/fidelity.py
+++ b/beanhub_extract/extractors/fidelity.py
@@ -16,7 +16,7 @@ DATE_FIELD = "Run Date"
 
 
 def beanify_account(name: str) -> str:
-    rst = re.sub(r"[^a-zA-Z0-9-_: ]", "", name)
+    rst = re.sub(r"[^a-zA-Z0-9-_ ]", "", name)
     rst = re.sub(r"[ \t\n\r\v\f]", " ", rst)
     rst = re.sub(r"[ ]{2,}", " ", rst)
     rst = rst.replace(" ", "-")
@@ -108,6 +108,7 @@ class FidelityExtractor(ExtractorBase):
                 return reader.fieldnames == self.ALL_FIELDS
         except Exception:
             pass
+
         return False
 
     def fingerprint(self) -> Fingerprint | None:

--- a/beanhub_extract/extractors/fidelity.py
+++ b/beanhub_extract/extractors/fidelity.py
@@ -20,7 +20,7 @@ def beanify_account(name: str) -> str:
     rst = re.sub(r"[ \t\n\r\v\f]", " ", rst)
     rst = re.sub(r"[ ]{2,}", " ", rst)
     rst = rst.replace(" ", "-")
-    return rst
+    return rst.title()
 
 
 def parse_date(date_str: str) -> datetime.date:

--- a/tests/extractors/test_extractor.py
+++ b/tests/extractors/test_extractor.py
@@ -1,7 +1,6 @@
 import pathlib
 
 import pytest
-
 from beanhub_extract.extractors import detect_extractor
 
 
@@ -12,8 +11,8 @@ from beanhub_extract.extractors import detect_extractor
         ("chase_credit_card.csv", "chase_credit_card"),
         ("csv.csv", "csv"),
         ("wealthsimple.csv", "wealthsimple"),
-        ("citi.csv", "citi_credit_card"),
         ("fidelity.csv", "fidelity"),
+        ("citi.csv", "citi_credit_card"),
         ("other.csv", None),
         (pytest.lazy_fixture("zip_file"), None),
     ],

--- a/tests/extractors/test_fidelity.py
+++ b/tests/extractors/test_fidelity.py
@@ -110,7 +110,7 @@ transactions = [
             "Account": "Person (CASH)",
             "Account Number": "Z26543467",
             "Action": "TRANSFERRED TO VS Z30-309107-1 (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -158,7 +158,7 @@ transactions = [
             "Account": "Savings",
             "Account Number": "Z30309107",
             "Action": "TRANSFERRED FROM VS Z26-543467-1 (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -206,7 +206,7 @@ transactions = [
             "Account": "Savings",
             "Account Number": "Z30309107",
             "Action": "DIRECT DEBIT CAPITAL ONE ACCTVERIFY (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -254,7 +254,7 @@ transactions = [
             "Account": "Person (CASH)",
             "Account Number": "Z26543467",
             "Action": "Electronic Funds Transfer Received (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -302,7 +302,7 @@ transactions = [
             "Account": "Person (CASH)",
             "Account Number": "Z26543467",
             "Action": "TRANSFERRED TO VS Z30-309107-1 (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -350,7 +350,7 @@ transactions = [
             "Account": "Savings",
             "Account Number": "Z30309107",
             "Action": "TRANSFERRED FROM VS Z26-543467-1 (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -398,7 +398,7 @@ transactions = [
             "Account": "Savings",
             "Account Number": "Z30309107",
             "Action": "Electronic Funds Transfer Received (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -446,7 +446,7 @@ transactions = [
             "Account": "Savings",
             "Account Number": "Z30309107",
             "Action": "Electronic Funds Transfer Received (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -494,7 +494,7 @@ transactions = [
             "Account": "Person (CASH)",
             "Account Number": "Z26543467",
             "Action": "Electronic Funds Transfer Received (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -542,7 +542,7 @@ transactions = [
             "Account": "Savings",
             "Account Number": "Z30309107",
             "Action": "Electronic Funds Transfer Received (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -638,7 +638,7 @@ transactions = [
             "Account": "Other Person (CASH)",
             "Account Number": "Z27376330",
             "Action": "DIRECT DEBIT VENMO ACCTVERIFY (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -686,7 +686,7 @@ transactions = [
             "Account": "Other Person (CASH)",
             "Account Number": "Z27376330",
             "Action": "DIRECT DEBIT VENMO ACCTVERIFY (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -734,7 +734,7 @@ transactions = [
             "Account": "Other Person (CASH)",
             "Account Number": "Z27376330",
             "Action": "Electronic Funds Transfer Received (Cash)",
-            "Symbol": " ",
+            "Symbol": "",
             "Description": "No Description",
             "Type": "Cash",
             "Exchange Quantity": "0",
@@ -1210,14 +1210,13 @@ def test_extractor(
 
 
 def test_fingerprint(fixtures_folder: pathlib.Path):
-    with open(fixtures_folder / "fidelity.csv", "rb") as fo:
+    input_file = fixtures_folder / "fidelity.csv"
+    with open(input_file, "rt") as fo:
         extractor = FidelityExtractor(fo)
         assert (
             pathlib.Path(extractor.input_file.name).name
             == pathlib.Path(input_file).name
         )
-
-        assert extractor._row_count == 24  # count starts on first valid row
 
         for tr in extractor():
             if tr.source_account is not None:


### PR DESCRIPTION
The `beanify` function had a bug that caused it to strip a space.

- before: `beanify("Account Name (CASH)") -> "AccountNameCASH"`
- after: `beanify("Account Name (CASH)") -> "Account-Name-CASH"`